### PR TITLE
Add Default Port for webpack.  As a developer not familiar with moder…

### DIFF
--- a/src/Client/webpack.config.js
+++ b/src/Client/webpack.config.js
@@ -42,7 +42,8 @@ module.exports = {
       }
     },
     hot: true,
-    inline: true
+    inline: true,
+    port: 8080
   },
   module: {
     rules: [


### PR DESCRIPTION
I am a new developer not familiar with all the tooling involved with the SAFE stack.  When running the SAFE-Dojo project I had a port conflict because of other services running on my machine.  I attempted to search the repo for port 8080 but it wasn't specified in the code.  This lead to frustration to not even be able to start the tutorial until I learn more of the tooling.

I just added the 8080 port into the client config in case anyone else runs into a similar issue and tries to search for 8080 to change it.

The API server uses port 8085 which is already written into the code.
