### PR TITLE
Updated prerequisites to specifiy dotnet sdk 2.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Please read the [instructions.md](Instructions.md) for a guide on completing thi
 
 ## Prerequisites
 
-* [.NET Core SDK 2.x](https://www.microsoft.com/net/download/) installed
+* [dotnet SDK 2.1.4](https://github.com/dotnet/cli/releases/tag/v2.1.4) The .NET Core SDK
 * [Yarn](https://yarnpkg.com/lang/en/docs/install/) package manager
 * [Node 8.x](https://nodejs.org/en/download/) installed for the front end components
 * [Mono](https://www.mono-project.com/docs/getting-started/install/) if you're running on Linux or OSX


### PR DESCRIPTION
I had dotnet sdk 2.1.300 installed initially and got an exception on the InstallClient task in build.sh.
I opened an issue and then closed it because installing dotnet sdk 2.1.4 fixed the problem:
https://github.com/CompositionalIT/SAFE-Dojo/issues/28
So I created this PR to update the prerequisites in the readme to be same as safe bookstore.
