### PR TITLE
Update tasks.json to make CMD+shift+B work out of the box

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
     "tasks": [
         {
             "label": "Run SAFE app",
-            "command": "build",
+            "command": "fake build -t run",
             "type": "shell",
             "group": {
                 "kind": "build",


### PR DESCRIPTION
`build` isn't a valid command in the current tasks.json, but `fake build -t run` works just fine.