### PR TITLE
#77: Fix input should not be null for postcode

### DIFF
--- a/src/Client/App.fs
+++ b/src/Client/App.fs
@@ -37,7 +37,7 @@ type Msg =
 
 /// The init function is called to start the message pump with an initial view.
 let init () =
-    { Postcode = null
+    { Postcode = ""
       Report = None
       ValidationError = None
       ServerState = Idle }, Cmd.ofMsg (PostcodeChanged "")


### PR DESCRIPTION
Error was visible through the console. Fix is to simply add an empty string.

Fix for https://github.com/CompositionalIT/SAFE-Dojo/issues/77 