### PR TITLE
Add global.json for pinning to .NET SDK 3.1

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.404",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
I wasn't able to start server when running .NET SDK 5. When I added a `global.json` for pinning to SDK 3.1, then I managed to start it. I thought a `global.json` would be a good addition.

// cc @isaacabraham