### PR TITLE
Metaweather alternative

### DIFF
--- a/src/Client/Index.fs
+++ b/src/Client/Index.fs
@@ -163,7 +163,7 @@ module ViewParts =
                     prop.children [
                         Html.img [
                             prop.style [ style.height 100]
-                            prop.src (sprintf "https://www.metaweather.com/static/img/weather/%s.svg" weatherReport.WeatherType.Abbreviation) ]
+                            prop.src (sprintf "https://raw.githubusercontent.com/erikflowers/weather-icons/master/svg/wi-%s.svg" weatherReport.WeatherType.IconName) ]
                         ]
                     ]
                 Bulma.table [

--- a/src/Server/Api.fs
+++ b/src/Server/Api.fs
@@ -29,14 +29,9 @@ let getCrimeReport postcode = async {
     return crimes
 }
 
-let private asWeatherResponse (weather: Weather.MetaWeatherLocation.Root) =
-    { WeatherType =
-        weather.ConsolidatedWeather
-        |> Array.countBy(fun w -> w.WeatherStateName)
-        |> Array.maxBy snd
-        |> fst
-        |> WeatherType.Parse
-      AverageTemperature = weather.ConsolidatedWeather |> Array.averageBy(fun r -> float r.TheTemp) }
+let private asWeatherResponse (weather: Weather.OpenMeteoCurrentWeather.CurrentWeather) =
+    { WeatherType = weather.Weathercode |> WeatherType.FromCode
+      Temperature = float weather.Temperature }
 
 let getWeather postcode = async {
     (* Task 4.1 WEATHER: Implement a function that retrieves the weather for

--- a/src/Server/Api.fs
+++ b/src/Server/Api.fs
@@ -41,7 +41,7 @@ let getWeather postcode = async {
 
     let emptyWeather =
         { WeatherType = WeatherType.Clear
-          AverageTemperature = 0. }
+          Temperature = 0. }
     return emptyWeather
 }
 

--- a/src/Server/DataAccess.fs
+++ b/src/Server/DataAccess.fs
@@ -42,15 +42,11 @@ module Crime =
 
 [<AutoOpen>]
 module Weather =
-    type MetaWeatherSearch = JsonProvider<"https://www.metaweather.com/api/location/search/?lattlong=51.5074,0.1278">
-    type MetaWeatherLocation = JsonProvider<"https://www.metaweather.com/api/location/1393672">
+    type OpenMeteoCurrentWeather = JsonProvider<"https://api.open-meteo.com/v1/forecast?latitude=51.5074&longitude=0.1278&current_weather=true">
     let getWeatherForPosition location = async {
-        let! locations =
+        let! weatherInfo =
             (location.Latitude, location.Longitude)
-            ||> sprintf "https://www.metaweather.com/api/location/search/?lattlong=%f,%f"
-            |> MetaWeatherSearch.AsyncLoad
-        let bestLocationId = locations |> Array.sortBy (fun t -> t.Distance) |> Array.map (fun o -> o.Woeid) |> Array.head
-        return!
-            bestLocationId
-            |> sprintf "https://www.metaweather.com/api/location/%d"
-            |> MetaWeatherLocation.AsyncLoad }
+            ||> sprintf "https://api.open-meteo.com/v1/forecast?latitude=%f&longitude=%f&current_weather=true"
+            |> OpenMeteoCurrentWeather.AsyncLoad
+        return
+            weatherInfo.CurrentWeather }

--- a/src/Shared/Shared.fs
+++ b/src/Shared/Shared.fs
@@ -19,23 +19,44 @@ type CrimeResponse =
       Incidents: int }
 
 type WeatherType =
+    | Clear
+    | SandStorm
+    | Fog
+    | Thunderstorm
+    | Drizzle
+    | Rain
     | Snow
     | Sleet
-    | Hail
-    | Thunder
-    | HeavyRain
-    | LightRain
     | Showers
-    | HeavyCloud
-    | LightCloud
-    | Clear
+    | Hail
 
-    static member Parse (s: string) =
-        let weatherTypes = Reflection.FSharpType.GetUnionCases typeof<WeatherType>
-        let case =
-            weatherTypes
-            |> Array.find(fun w -> w.Name = s.Replace(" ", ""))
-        FSharp.Reflection.FSharpValue.MakeUnion(case, [| |]) :?> WeatherType
+    // WMO codes in open-meteo response seem to be WMO 4677
+    // See eg: https://www.nodc.noaa.gov/archive/arc0021/0002199/1.1/data/0-data/HTML/WMO-CODE/WMO4677.HTM
+    static member FromCode (weathercode: int) =
+        match weathercode with
+        | w when w = 9 -> SandStorm
+        | w when w = 11 || w = 12 -> Fog
+        | w when w = 17 -> Thunderstorm
+        | w when w >= 0 && w <= 19 -> Clear
+        | w when w = 20 -> Drizzle
+        | w when w = 21 -> Rain
+        | w when w = 22 -> Snow
+        | w when w = 23 || w = 24 -> Sleet
+        | w when w >= 25 && w <= 27 -> Showers
+        | w when w = 28 -> Fog
+        | w when w = 29 -> Thunderstorm
+        | w when w >= 30 && w <= 35 -> SandStorm
+        | w when w >= 36 && w <= 39 -> Snow
+        | w when w >= 40 && w <= 49 -> Fog
+        | w when w >= 50 && w <= 59 -> Drizzle
+        | w when w >= 60 && w <= 69 -> Rain
+        | w when w >= 70 && w <= 78 -> Snow
+        | w when w = 79 -> Hail
+        | w when w >= 80 && w <= 90 -> Showers
+        | w when w = 91 || w = 92 -> Rain
+        | w when w = 93 || w = 94 -> Snow
+        | w when w >= 95 && w <= 99 -> Thunderstorm
+        | _ -> Clear
 
     member this.Abbreviation =
         match this with
@@ -44,7 +65,7 @@ type WeatherType =
 
 type WeatherResponse =
     { WeatherType: WeatherType
-      AverageTemperature: float }
+      Temperature: float }
 
 module Route =
     let builder = sprintf "/api/%s/%s"

--- a/src/Shared/Shared.fs
+++ b/src/Shared/Shared.fs
@@ -58,10 +58,18 @@ type WeatherType =
         | w when w >= 95 && w <= 99 -> Thunderstorm
         | _ -> Clear
 
-    member this.Abbreviation =
+    member this.IconName =
         match this with
-        | Snow -> "sn" | Sleet -> "sl" | Hail -> "h" | Thunder -> "t" | HeavyRain -> "hr"
-        | LightRain -> "lr" | Showers -> "s" | HeavyCloud -> "hc" | LightCloud -> "lc" | Clear -> "c"
+        | Clear -> "day-sunny" // improvement: return "night-clear" at night time
+        | SandStorm -> "sandstorm"
+        | Fog -> "fog"
+        | Thunderstorm -> "thunderstorm"
+        | Drizzle -> "raindrops"
+        | Rain -> "rain"
+        | Snow -> "snow"
+        | Sleet -> "sleet"
+        | Showers -> "showers"
+        | Hail -> "hail"
 
 type WeatherResponse =
     { WeatherType: WeatherType


### PR DESCRIPTION
[metaweather.com](http://metaweather.com) is down. This PR changes the code to use [open-meteo.com](http://open-meteo.com)'s API and display [open source weather icons](https://github.com/erikflowers/weather-icons) instead.